### PR TITLE
feat(glob): Enable symlink following for file search

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -60110,7 +60110,7 @@ ${segment}` : segment;
   async indexVault(vaultPath, force = false) {
     const embedder = Embedder.getInstance();
     const db = await this.getDb();
-    const files = await glob("**/*.md", { cwd: vaultPath, absolute: true });
+    const files = await glob("**/*.md", { cwd: vaultPath, absolute: true, follow: true });
     console.error(`Found ${files.length} notes in ${vaultPath}`);
     let previousHashes = {};
     if (!force) {
@@ -60396,7 +60396,7 @@ async function readStdin() {
         const vp = getVaultPath(parsedArgs.vault_path);
         const sub = parsedArgs.subfolder ? String(parsedArgs.subfolder) : "**";
         const pattern = path5.join(sub, "*.md");
-        const files = await glob(pattern, { cwd: vp });
+        const files = await glob(pattern, { cwd: vp, follow: true });
         result = JSON.stringify(files.slice(0, 100), null, 2) + (files.length > 100 ? `
 ...and ${files.length - 100} more.` : "");
       } else if (toolName === "obsidian_read_note") {
@@ -60435,7 +60435,7 @@ async function readStdin() {
       } else if (toolName === "obsidian_search_notes") {
         const vp = getVaultPath(parsedArgs.vault_path);
         const query = String(parsedArgs.query).toLowerCase();
-        const files = await glob("**/*.md", { cwd: vp });
+        const files = await glob("**/*.md", { cwd: vp, follow: true });
         const matches = [];
         for (const f of files) {
           if (f.toLowerCase().includes(query)) {
@@ -60482,7 +60482,7 @@ Content: ${r.text}`).join("\n---\n");
         const vp = getVaultPath(parsedArgs.vault_path);
         const target = String(parsedArgs.file_name).replace(/\.md$/i, "");
         const linkRegex = new RegExp(`\\[\\[${target.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}([\\]\\|#])`, "i");
-        const files = await glob("**/*.md", { cwd: vp });
+        const files = await glob("**/*.md", { cwd: vp, follow: true });
         const backlinks = [];
         const batchSize = 50;
         for (let i2 = 0; i2 < files.length; i2 += batchSize) {
@@ -60780,7 +60780,7 @@ Content: ${r.text}`).join("\n---\n");
         const vp = getVaultPath(args2?.vault_path);
         const sub = args2?.subfolder ? String(args2.subfolder) : "**";
         const pattern = path5.join(sub, "*.md");
-        const files = await glob(pattern, { cwd: vp });
+        const files = await glob(pattern, { cwd: vp, follow: true });
         return { content: [{ type: "text", text: JSON.stringify(files.slice(0, 100), null, 2) + (files.length > 100 ? `
 ...and ${files.length - 100} more.` : "") }] };
       }
@@ -60826,7 +60826,7 @@ Content: ${r.text}`).join("\n---\n");
       if (name2 === "obsidian_search_notes") {
         const vp = getVaultPath(args2?.vault_path);
         const query = String(args2?.query).toLowerCase();
-        const files = await glob("**/*.md", { cwd: vp });
+        const files = await glob("**/*.md", { cwd: vp, follow: true });
         const matches = [];
         for (const f of files) {
           if (f.toLowerCase().includes(query)) {
@@ -60871,7 +60871,7 @@ Content: ${r.text}
         const vp = getVaultPath(args2?.vault_path);
         const target = String(args2?.file_name).replace(/\.md$/i, "");
         const linkRegex = new RegExp(`\\[\\[${target.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}([\\]\\|#])`, "i");
-        const files = await glob("**/*.md", { cwd: vp });
+        const files = await glob("**/*.md", { cwd: vp, follow: true });
         const backlinks = [];
         const batchSize = 50;
         for (let i2 = 0; i2 < files.length; i2 += batchSize) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gemini-obsidian",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gemini-obsidian",
-      "version": "1.2.0",
+      "version": "1.4.0",
       "license": "ISC",
       "dependencies": {
         "@lancedb/lancedb": "^0.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini-obsidian",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Obsidian Vault integration with local RAG capabilities",
   "main": "index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,7 +123,7 @@ async function readStdin(): Promise<string> {
             const vp = getVaultPath(parsedArgs.vault_path);
             const sub = parsedArgs.subfolder ? String(parsedArgs.subfolder) : '**';
             const pattern = path.join(sub, '*.md');
-            const files = await glob(pattern, { cwd: vp });
+            const files = await glob(pattern, { cwd: vp, follow: true });
             result = JSON.stringify(files.slice(0, 100), null, 2) + (files.length > 100 ? `\n...and ${files.length - 100} more.` : '');
         } else if (toolName === 'obsidian_read_note') {
             const vp = getVaultPath(parsedArgs.vault_path);
@@ -159,7 +159,7 @@ async function readStdin(): Promise<string> {
         } else if (toolName === 'obsidian_search_notes') {
             const vp = getVaultPath(parsedArgs.vault_path);
             const query = String(parsedArgs.query).toLowerCase();
-            const files = await glob('**/*.md', { cwd: vp });
+            const files = await glob('**/*.md', { cwd: vp, follow: true });
             const matches: string[] = [];
             for (const f of files) {
                 if (f.toLowerCase().includes(query)) {
@@ -204,7 +204,7 @@ async function readStdin(): Promise<string> {
             const target = String(parsedArgs.file_name).replace(/\.md$/i, ''); 
             const linkRegex = new RegExp(`\\[\\[${target.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}([\\]\\|#])`, 'i');
             
-            const files = await glob('**/*.md', { cwd: vp });
+            const files = await glob('**/*.md', { cwd: vp, follow: true });
             
             const backlinks: string[] = [];
             const batchSize = 50;
@@ -496,7 +496,7 @@ async function readStdin(): Promise<string> {
           const vp = getVaultPath(args?.vault_path as string);
           const sub = args?.subfolder ? String(args.subfolder) : '**';
           const pattern = path.join(sub, '*.md');
-          const files = await glob(pattern, { cwd: vp });
+          const files = await glob(pattern, { cwd: vp, follow: true });
           return { content: [{ type: 'text', text: JSON.stringify(files.slice(0, 100), null, 2) + (files.length > 100 ? `\n...and ${files.length - 100} more.` : '') }] };
       }
       if (name === 'obsidian_read_note') {
@@ -539,7 +539,7 @@ async function readStdin(): Promise<string> {
       if (name === 'obsidian_search_notes') {
           const vp = getVaultPath(args?.vault_path as string);
           const query = String(args?.query).toLowerCase();
-          const files = await glob('**/*.md', { cwd: vp });
+          const files = await glob('**/*.md', { cwd: vp, follow: true });
           const matches: string[] = [];
           for (const f of files) {
               if (f.toLowerCase().includes(query)) {
@@ -579,7 +579,7 @@ async function readStdin(): Promise<string> {
           const target = String(args?.file_name).replace(/\.md$/i, ''); 
           const linkRegex = new RegExp(`\\[\\[${target.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}([\\]\\|#])`, 'i');
           
-          const files = await glob('**/*.md', { cwd: vp });
+          const files = await glob('**/*.md', { cwd: vp, follow: true });
           
           // Parallel processing with simple concurrency control (batches of 50)
           const backlinks: string[] = [];

--- a/src/rag/store.ts
+++ b/src/rag/store.ts
@@ -232,7 +232,7 @@ export class VaultIndexer {
     const db = await this.getDb();
 
     // Find all markdown files
-    const files = await glob('**/*.md', { cwd: vaultPath, absolute: true });
+    const files = await glob('**/*.md', { cwd: vaultPath, absolute: true, follow: true });
     console.error(`Found ${files.length} notes in ${vaultPath}`);
 
     // Load previous file hashes for incremental indexing


### PR DESCRIPTION
### Summary

This change updates all file search operations to follow symbolic links within the user's vault. Many Obsidian users use symlinks to include folders from other locations in their vault, and this change ensures those files are correctly discovered and indexed.

### Changes

-   `src/rag/store.ts`: Updated the `indexVault` function to pass `{ follow: true }` to `glob`, enabling the semantic indexer to find notes in symlinked directories.
-   `src/index.ts`: Updated the `obsidian_list_notes`, `obsidian_search_notes`, and `obsidian_get_backlinks` tool handlers to pass `{ follow: true }` to their respective `glob` calls, ensuring consistent behavior for all file discovery features.
-   `package.json`: Bumped the package version to `1.4.0` to reflect the new feature.

### Motivation

Currently, the extension does not traverse symlinked directories when searching for markdown files. This prevents users who organize their vaults with symlinks from having those files included in search results or the semantic index. This PR resolves that limitation.

### Testing

To test this change:
-   Inside your test vault, create a symbolic link to a directory that contains markdown files.
    ```sh
    ln -s /path/to/another/folder_with_notes /path/to/your/vault/symlinked_notes
    ```
-   Run the indexer: `/obsidian:index`.
-   Confirm that the output includes files from the `symlinked_notes` directory.
-   Search for content known to be in one of the symlinked notes: `/obsidian:ask "content from symlinked note"`.
-   Verify that the search returns the expected results.
