### PR TITLE
[codex] Fix Windows hook execution

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,7 +7,7 @@
           {
             "name": "obsidian-session-init",
             "type": "command",
-            "command": "bash ${extensionPath}/scripts/session-init.sh",
+            "command": "node ${extensionPath}/scripts/session-init.js",
             "timeout": 120000,
             "description": "Reports vault status and refreshes the RAG index when a Gemini session starts."
           }
@@ -21,7 +21,7 @@
           {
             "name": "obsidian-validate-frontmatter",
             "type": "command",
-            "command": "bash ${extensionPath}/scripts/validate-frontmatter.sh",
+            "command": "node ${extensionPath}/scripts/validate-frontmatter.js",
             "timeout": 10000,
             "description": "Blocks note creation when required frontmatter fields are missing."
           }
@@ -35,7 +35,7 @@
           {
             "name": "obsidian-reindex",
             "type": "command",
-            "command": "bash ${extensionPath}/scripts/reindex-note.sh",
+            "command": "node ${extensionPath}/scripts/reindex-note.js",
             "timeout": 30000,
             "description": "Re-indexes only the changed note after it is created or modified."
           }

--- a/scripts/reindex-note.js
+++ b/scripts/reindex-note.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const { spawn } = require('child_process');
+
+const PLUGIN_ROOT = path.resolve(__dirname, '..');
+const CLI_PATH = path.join(PLUGIN_ROOT, 'dist', 'index.js');
+
+async function readStdin() {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => {
+      data += chunk;
+    });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
+}
+
+async function main() {
+  const input = await readStdin();
+  const child = spawn(process.execPath, [CLI_PATH, 'obsidian_rag_index', '--hook'], {
+    stdio: ['pipe', 'ignore', 'ignore'],
+    env: process.env,
+    windowsHide: true,
+  });
+
+  if (input) {
+    child.stdin.write(input);
+  }
+  child.stdin.end();
+
+  child.on('close', () => {
+    process.stdout.write('{}\n');
+    process.exit(0);
+  });
+}
+
+main().catch(() => {
+  process.stdout.write('{}\n');
+  process.exit(0);
+});

--- a/scripts/session-init.js
+++ b/scripts/session-init.js
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+
+const fs = require('fs/promises');
+const os = require('os');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const CONFIG_FILE = path.join(os.homedir(), '.gemini-obsidian.config.json');
+const PLUGIN_ROOT = path.resolve(__dirname, '..');
+const CLI_PATH = path.join(PLUGIN_ROOT, 'dist', 'index.js');
+
+async function loadVaultPath() {
+  if (process.env.OBSIDIAN_VAULT_PATH) {
+    return process.env.OBSIDIAN_VAULT_PATH;
+  }
+
+  try {
+    const raw = await fs.readFile(CONFIG_FILE, 'utf8');
+    return JSON.parse(raw).vault_path || '';
+  } catch {
+    return '';
+  }
+}
+
+async function countMarkdownFiles(root) {
+  let count = 0;
+  const queue = [root];
+
+  while (queue.length > 0) {
+    const current = queue.pop();
+    let entries;
+    try {
+      entries = await fs.readdir(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      const fullPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        queue.push(fullPath);
+      } else if (entry.isFile() && entry.name.toLowerCase().endsWith('.md')) {
+        count += 1;
+      }
+    }
+  }
+
+  return count;
+}
+
+async function runCli(args, input) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [CLI_PATH, ...args], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: process.env,
+      windowsHide: true,
+    });
+
+    let stdout = '';
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr.resume();
+
+    child.on('close', (code) => {
+      resolve({ code: code ?? 1, stdout });
+    });
+
+    if (input) {
+      child.stdin.write(input);
+    }
+    child.stdin.end();
+  });
+}
+
+async function main() {
+  const vaultPath = await loadVaultPath();
+  let message;
+
+  try {
+    const stat = vaultPath ? await fs.stat(vaultPath) : null;
+    if (vaultPath && stat.isDirectory()) {
+      const noteCount = await countMarkdownFiles(vaultPath);
+      const statusLine = `Obsidian vault connected: ${vaultPath} (${noteCount} notes)`;
+      const indexResult = await runCli(['obsidian_rag_index'], '');
+
+      let indexLine = 'RAG index refresh failed';
+      if (indexResult.code === 0) {
+        try {
+          const parsed = JSON.parse(indexResult.stdout || '{}');
+          if (parsed.chunks === 0) {
+            indexLine = 'RAG index up to date';
+          } else if (typeof parsed.chunks === 'number') {
+            indexLine = `RAG index updated: ${parsed.chunks} chunks indexed`;
+          } else {
+            indexLine = 'RAG index check completed';
+          }
+        } catch {
+          indexLine = 'RAG index check completed';
+        }
+      }
+
+      message = `${statusLine}\n${indexLine}`;
+    } else {
+      message = 'Obsidian vault not configured. Use obsidian_set_vault to set your vault path.';
+    }
+  } catch {
+    message = 'Obsidian vault not configured. Use obsidian_set_vault to set your vault path.';
+  }
+
+  process.stdout.write(`${JSON.stringify({ systemMessage: message, suppressOutput: true })}\n`);
+}
+
+main().catch(() => {
+  process.stdout.write(
+    `${JSON.stringify({
+      systemMessage: 'Obsidian vault not configured. Use obsidian_set_vault to set your vault path.',
+      suppressOutput: true,
+    })}\n`,
+  );
+});

--- a/scripts/validate-frontmatter.js
+++ b/scripts/validate-frontmatter.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const { spawn } = require('child_process');
+
+const PLUGIN_ROOT = path.resolve(__dirname, '..');
+const CLI_PATH = path.join(PLUGIN_ROOT, 'dist', 'index.js');
+
+async function readStdin() {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => {
+      data += chunk;
+    });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
+}
+
+async function main() {
+  const input = await readStdin();
+  const child = spawn(process.execPath, [CLI_PATH, 'validate_frontmatter', '--hook'], {
+    stdio: ['pipe', 'ignore', 'ignore'],
+    env: process.env,
+    windowsHide: true,
+  });
+
+  if (input) {
+    child.stdin.write(input);
+  }
+  child.stdin.end();
+
+  child.on('close', (code) => {
+    if ((code ?? 1) === 0) {
+      process.stdout.write('{}\n');
+      process.exit(0);
+    }
+
+    process.exit(code ?? 1);
+  });
+}
+
+main().catch(() => process.exit(1));

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+type HookEntry = {
+  command: string;
+  name: string;
+};
+
+function loadHookCommands(): HookEntry[] {
+  const hooksPath = path.join(__dirname, '..', 'hooks', 'hooks.json');
+  const parsed = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
+
+  return [
+    ...parsed.hooks.SessionStart[0].hooks,
+    ...parsed.hooks.BeforeTool[0].hooks,
+    ...parsed.hooks.AfterTool[0].hooks,
+  ].map(({ command, name }) => ({ command, name }));
+}
+
+describe('hook commands', () => {
+  it('uses node wrappers for cross-platform execution', () => {
+    expect(loadHookCommands()).toEqual([
+      {
+        name: 'obsidian-session-init',
+        command: 'node ${extensionPath}/scripts/session-init.js',
+      },
+      {
+        name: 'obsidian-validate-frontmatter',
+        command: 'node ${extensionPath}/scripts/validate-frontmatter.js',
+      },
+      {
+        name: 'obsidian-reindex',
+        command: 'node ${extensionPath}/scripts/reindex-note.js',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
This PR fixes hook execution on Windows by replacing the `bash`-based hook commands with Node wrapper scripts.

## Root Cause
The extension currently configures hooks like `bash ${extensionPath}/scripts/session-init.sh`.
On Windows, that can fail when `bash` resolves to `C:\Windows\System32\bash.exe` (WSL bash), because Gemini passes a Windows path while WSL expects `/mnt/c/...` style paths. The shell scripts can also fail when checked out with CRLF line endings.

## What Changed
- switched `hooks/hooks.json` to call `node` wrappers instead of `bash` shell scripts
- added `scripts/session-init.js`
- added `scripts/validate-frontmatter.js`
- added `scripts/reindex-note.js`
- added `test/hooks.test.ts` to lock the hook commands to the cross-platform Node wrappers

## Validation
- `npm run type-check`
- `npx vitest run test/hooks.test.ts`
- `node scripts/session-init.js`
- `node scripts/validate-frontmatter.js`
- `node scripts/reindex-note.js`

## Notes
- `npm test` still reports unrelated Windows failures in `test/utils.test.ts` and `test/vault-ops.test.ts`; this PR does not touch those areas.

Fixes #17
